### PR TITLE
add `data-dojo-config="async: true"` to js api script tag

### DIFF
--- a/src/app/index.html
+++ b/src/app/index.html
@@ -7,7 +7,7 @@
 
     <body>
         <div id="content"></div>
-        <script src="https://js.arcgis.com/3.16/"></script>
+        <script src="https://js.arcgis.com/3.16/" data-dojo-config="async: true"></script>
         <script>
             require(["/dist/vendor.bundle.js", "/dist/main.bundle.js"], function (vendor, main) {});
         </script>


### PR DESCRIPTION
Fixes issue #3: webpack bundles are fetched multiple times
